### PR TITLE
add travisgrabber

### DIFF
--- a/data.json
+++ b/data.json
@@ -96,15 +96,15 @@
   }
  },
  "BurpSuite": {
-  "Type": "Army-Knife",
   "Data": "| Army-Knife/PROXY  | [BurpSuite](https://portswigger.net/burp) |  the BurpSuite Project|![](https://img.shields.io/static/v1?label=\u0026message=it's%20not%20github\u0026color=gray)|![](https://img.shields.io/static/v1?label=\u0026message=it's%20not%20github\u0026color=gray)",
-  "Method": "PROXY",
   "Description": "the BurpSuite Project",
   "Install": {
    "Linux": "",
    "MacOS": "",
    "Windows": ""
   },
+  "Method": "PROXY",
+  "Type": "Army-Knife",
   "Update": {
    "Linux": "",
    "MacOS": "",
@@ -2073,6 +2073,22 @@
   },
   "Method": "FUZZ",
   "Type": "Scanner",
+  "Update": {
+   "Linux": "",
+   "MacOS": "",
+   "Windows": ""
+  }
+ },
+ "travis-grabber": {
+  "Type": "Discovery",
+  "Data": "| Discovery/CI | [travis-grabber](https://github.com/bug-bounty-collection/travis-grabber) | grabs all logs for all jobs for a given org from travis | ![](https://img.shields.io/github/stars/bug-bounty-collection/travis-grabber) | ![](https://img.shields.io/github/languages/top/bug-bounty-collection/travis-grabber) |",
+  "Method": "CI",
+  "Description": "grabs all logs for all jobs for a given org from travis",
+  "Install": {
+   "Linux": "",
+   "MacOS": "",
+   "Windows": ""
+  },
   "Update": {
    "Linux": "",
    "MacOS": "",


### PR DESCRIPTION
Discovery tool to get all builds logs for given github org from travis.
The idea being the later use tool like [gf](github.com/tomnomnom/gf) to scan those for secrets or other interesting patterns