### PR TITLE
Add BugBountyScanner

### DIFF
--- a/weapons/BugBountyScanner.yaml
+++ b/weapons/BugBountyScanner.yaml
@@ -1,0 +1,9 @@
+---
+name: BugBountyScanner
+description: A Bash script and Docker image for Bug Bounty reconnaissance.
+url: https://github.com/chvancooten/BugBountyScanner
+category: tool
+type: Recon
+platform: [linux, macos, windows]
+lang: Shell
+tags: []


### PR DESCRIPTION
This pull request adds the BugBountyScanner tool, a Bash script and Docker image for Bug Bounty reconnaissance. The tool can be found at [this link](https://github.com/chvancooten/BugBountyScanner). It falls under the category of tool, specifically Recon, and is compatible with Linux, macOS, and Windows. The script is written in Shell.