### PR TITLE
Make Windows contributor validation match CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+*.yaml text eol=lf
+*.yml text eol=lf
+*.rb text eol=lf
+*.md text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.hermes/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "redhat.vscode-yaml"
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,65 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "WHW: lint YAML",
+            "type": "shell",
+            "command": "python -m yamllint -c .yamllint.yml weapons",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "WHW: validate weapons",
+            "type": "shell",
+            "command": "ruby ./scripts/validate_weapons.rb",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "WHW: generate README",
+            "type": "shell",
+            "command": "ruby ./scripts/erb.rb",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "WHW: restore generated docs",
+            "type": "shell",
+            "command": "git checkout -- README.md categorize",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "build",
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "WHW: lint YAML",
+                "WHW: validate weapons"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "WHW: full gate",
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "WHW: lint YAML",
+                "WHW: validate weapons",
+                "WHW: generate README",
+                "WHW: restore generated docs"
+            ],
+            "problemMatcher": []
+        }
+    ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,23 @@ tags: [xss, sqli]  # Vulnerability/feature tags
 3. **Content Validation**: `ruby ./scripts/validate_weapons.rb`
 4. **Manual Check**: Verify your tool appears in the generated README.md
 
+On Windows PowerShell, do not use `yamllint weapons/*.yaml` (glob does not expand). Use:
+
+```
+python -m yamllint -c .yamllint.yml weapons
+ruby ./scripts/validate_weapons.rb
+ruby ./scripts/erb.rb
+git checkout -- README.md categorize
+```
+
+Or: `powershell -File scripts/validate.ps1` then restore generated docs with `git checkout -- README.md categorize` on a PR branch.
+
+If yamllint reports `wrong new line character: expected \n`, refresh the working tree without changing git config:
+
+```
+git -c core.autocrlf=false checkout -- weapons
+```
+
 ## CI/CD Process
 - **Pull Requests**: Automatically run YAML linting via `.github/workflows/yaml-lint.yml`
 - **Main Branch**: Automatically regenerates README.md and categorize/* files via `.github/workflows/cd.yml`
@@ -70,8 +87,8 @@ tags: [xss, sqli]  # Vulnerability/feature tags
 ## Common Validation Issues
 - **"no new line character at the end of file"**: Add a blank line at the end of YAML files
 - **"none-lang" warnings**: Add appropriate `lang:` field for GitHub-hosted tools  
-- **"undefined method length"**: Ensure `tags:` field exists and is an array
-- **"Is a directory" errors**: Normal warnings from validation script reading directory entries
+- **"undefined method length"**: Ensure `tags:` field exists and is an array (`validate_weapons.rb` is nil-safe)
+- **"Is a directory" errors**: Should not appear; the validator only reads `weapons/*.yaml`
 
 ## Error Examples
 ```bash

--- a/scripts/erb.rb
+++ b/scripts/erb.rb
@@ -130,24 +130,23 @@ weapons_obj = {
     "etc"=> []
 }
 
-Dir.entries("./weapons/").each do | name |
-    if name != '.' && name != '..'
-        begin
-            data = YAML.load(File.open("./weapons/#{name}"))
+Dir.glob("./weapons/*.yaml").sort.each do |path|
+    name = File.basename(path)
+    begin
+        data = YAML.load(File.open(path))
 
-            if data['type'] != "" && data['type'] != nil
-                if weapons_obj[data['type'].downcase] != nil
-                    weapons_obj[data['type'].downcase].push data
-                else
-                    weapons_obj[data['type'].downcase] = []
-                    weapons_obj[data['type'].downcase].push data
-                end
+        if data['type'] != "" && data['type'] != nil
+            if weapons_obj[data['type'].downcase] != nil
+                weapons_obj[data['type'].downcase].push data
             else
-                weapons_obj['etc'].push data
+                weapons_obj[data['type'].downcase] = []
+                weapons_obj[data['type'].downcase].push data
             end
-        rescue => e
-            puts e
+        else
+            weapons_obj['etc'].push data
         end
+    rescue => e
+        puts e
     end
 end
 

--- a/scripts/validate.ps1
+++ b/scripts/validate.ps1
@@ -1,0 +1,21 @@
+$ErrorActionPreference = "Stop"
+Set-Location (Split-Path -Parent $PSScriptRoot)
+
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+$pyScripts = "$env:APPDATA\Python\Python314\Scripts"
+if (Test-Path $pyScripts) { $env:Path = "$pyScripts;$env:Path" }
+
+Write-Host "==> yamllint weapons/"
+python -m yamllint -c .yamllint.yml weapons
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host "==> ruby ./scripts/validate_weapons.rb"
+ruby ./scripts/validate_weapons.rb
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host "==> ruby ./scripts/erb.rb"
+ruby ./scripts/erb.rb
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host "OK. Inspect git status; do not commit README.md or categorize/* in a PR."
+git status --short

--- a/scripts/validate_weapons.rb
+++ b/scripts/validate_weapons.rb
@@ -1,22 +1,23 @@
 require 'yaml'
 
-Dir.entries("./weapons").each do | name |
-    if name.strip != "."  || name != ".."
-      begin
-        data = YAML.load(File.open("./weapons/#{name}"))
-        if data['type'] == "" || data['type'] == nil
-            puts "./weapons/#{name} :: none-type"
-        end
-        if data['lang'] == "" || data['lang'] == nil || data['lang'].length == 0
-          if data['url'].include? "github.com"
-            puts "./weapons/#{name} :: none-lang"
-          end
-        end
-        if data['tags'].length == 0 || data['tags'] == nil
-            #puts "#{name} :: none-tags"
-        end
-      rescue => e
-        puts e
+Dir.entries("./weapons").each do |name|
+  next unless name.end_with?(".yaml")
+
+  begin
+    data = YAML.load(File.open("./weapons/#{name}"))
+    if data['type'].to_s.empty?
+      puts "./weapons/#{name} :: none-type"
+    end
+    if data['lang'].to_s.empty?
+      if data['url'].to_s.include?("github.com")
+        puts "./weapons/#{name} :: none-lang"
       end
     end
+    tags = data['tags']
+    if tags.nil? || tags.length == 0
+      # puts "./weapons/#{name} :: none-tags"
+    end
+  rescue => e
+    puts "#{name} :: #{e}"
+  end
 end

--- a/weapons/BurpSuite-Secret_Finder.yaml
+++ b/weapons/BurpSuite-Secret_Finder.yaml
@@ -5,5 +5,5 @@ url: https://github.com/m4ll0k/BurpSuite-Secret_Finder
 category: tool-addon
 type: Recon
 platform: [linux, macos, windows, burpsuite]
-lang:
+lang: Python
 tags: []

--- a/weapons/CT_subdomains.yaml
+++ b/weapons/CT_subdomains.yaml
@@ -6,5 +6,5 @@ url: https://github.com/internetwache/CT_subdomains
 category: tool
 type: Recon
 platform: [linux, macos, windows]
-lang:
+lang: Txt
 tags: [subdomains]

--- a/weapons/Chromium-based-XSS-Taint-Tracking.yaml
+++ b/weapons/Chromium-based-XSS-Taint-Tracking.yaml
@@ -6,5 +6,5 @@ url: https://github.com/v8blink/Chromium-based-XSS-Taint-Tracking
 category: tool
 type: Scanner
 platform: [linux, macos, windows]
-lang:
+lang: C++
 tags: [xss]

--- a/weapons/Gf-Patterns.yaml
+++ b/weapons/Gf-Patterns.yaml
@@ -6,5 +6,5 @@ url: https://github.com/1ndianl33t/Gf-Patterns
 category: tool
 type: Utils
 platform: [linux, macos, windows]
-lang:
-tags:
+lang: Txt
+tags: []

--- a/weapons/PoC-in-GitHub.yaml
+++ b/weapons/PoC-in-GitHub.yaml
@@ -5,5 +5,5 @@ url: https://github.com/nomi-sec/PoC-in-GitHub
 category: tool
 type: Utils
 platform: [linux, macos, windows]
-lang:
+lang: Txt
 tags: []

--- a/weapons/Taipan.yaml
+++ b/weapons/Taipan.yaml
@@ -5,5 +5,5 @@ url: https://github.com/enkomio/Taipan
 category: tool
 type: Scanner
 platform: [linux, macos, windows]
-lang:
+lang: C#
 tags: []

--- a/weapons/can-i-take-over-xyz.yaml
+++ b/weapons/can-i-take-over-xyz.yaml
@@ -6,5 +6,5 @@ url: https://github.com/EdOverflow/can-i-take-over-xyz
 category: tool
 type: Utils
 platform: [linux, macos, windows]
-lang:
+lang: Python
 tags: []

--- a/weapons/httptoolkit.yaml
+++ b/weapons/httptoolkit.yaml
@@ -6,5 +6,5 @@ url: https://github.com/httptoolkit/httptoolkit
 category: tool
 type: Utils
 platform: [linux, macos, windows]
-lang:
+lang: TypeScript
 tags: []

--- a/weapons/subs_all.yaml
+++ b/weapons/subs_all.yaml
@@ -5,5 +5,5 @@ url: https://github.com/emadshanab/subs_all
 category: tool
 type: Recon
 platform: [linux, macos, windows]
-lang:
+lang: Txt
 tags: [subdomains]

--- a/weapons/xss-cheatsheet-data.yaml
+++ b/weapons/xss-cheatsheet-data.yaml
@@ -6,5 +6,5 @@ url: https://github.com/PortSwigger/xss-cheatsheet-data
 category: tool
 type: Utils
 platform: [linux, macos, windows]
-lang:
+lang: Txt
 tags: [xss]


### PR DESCRIPTION
## Summary
- Add LF `.gitattributes`, a PowerShell `scripts/validate.ps1` entrypoint, and Cursor `build` tasks so Windows agents can lint and validate without bash globs or msbuild.
- Sort `weapons/*.yaml` in `erb.rb` and skip non-YAML/nil `tags` in `validate_weapons.rb` so local runs do not crash or shuffle README order.
- Fill `lang:` on the GitHub tools that were warning `none-lang`, and document the Windows validate loop in `AGENTS.md`.

## Test plan
- [ ] `python -m yamllint -c .yamllint.yml weapons` exits 0
- [ ] `ruby ./scripts/validate_weapons.rb` exits 0 with no directory/`length` errors
- [ ] `ruby ./scripts/erb.rb` exits 0; do not commit generated `README.md` / `categorize/*`
- [ ] `powershell -File scripts/validate.ps1` then `git checkout -- README.md categorize` on a PR branch
- [ ] Cursor Run Build Task runs yamllint + validate_weapons (not msbuild)

Made with [Cursor](https://cursor.com)